### PR TITLE
Fix deployment failure when missing lambda version

### DIFF
--- a/templates/pre_buildspec.yml.tpl
+++ b/templates/pre_buildspec.yml.tpl
@@ -23,7 +23,7 @@ phases:
         aws lambda wait function-updated --function-name $FUNCTION_NAME
         TARGET_VERSION=$(aws lambda publish-version --function-name $FUNCTION_NAME --query 'Version' --output text)
         aws lambda wait published-version-active --function-name $FUNCTION_NAME --qualifier $TARGET_VERSION
-        CURRENT_VERSION=$(echo "$(($TARGET_VERSION-1))")
+        CURRENT_VERSION=$(aws lambda get-alias --function-name $FUNCTION_NAME --name live --query 'FunctionVersion' --output text)
         echo $APPSPEC > appspec.json
         sed -i -E 's/<FUNCTION_NAME>/'$FUNCTION_NAME'/' appspec.json
         sed -i -E 's/<CURRENT_VERSION>/'$CURRENT_VERSION'/' appspec.json


### PR DESCRIPTION
In current state the versions are calculated as published version and published version-1, this sometimes causes the build to fail if versions are not in running sequence,
THE FIX: get published version for latest, and current "Alias" version as current version 