### PR TITLE
adding source_repository argument to post step

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ module "build" {
       ADO_PASSWORD         = data.aws_ssm_parameter.ado_password.value,
       TEST_REPORT          = var.test_report_group,
       CODE_COVERAGE_REPORT = var.coverage_report_group
-      SOURCE_REPOSITORY = var.source_repository
+      SOURCE_REPOSITORY    = var.source_repository
   })
 }
 
@@ -112,7 +112,8 @@ module "post" {
       FROM_ENV               = var.from_env,
       APP_NAME               = var.app_name,
       ENV_TYPE               = var.env_type,
-      ENABLE_JIRA_AUTOMATION = var.enable_jira_automation
+      ENABLE_JIRA_AUTOMATION = var.enable_jira_automation,
+      SOURCE_REPOSITORY      = var.source_repository
   })
 }
 

--- a/templates/post_buildspec.yml.tpl
+++ b/templates/post_buildspec.yml.tpl
@@ -40,7 +40,7 @@ phases:
     commands:
       - |
         REPORT_URL="https://console.aws.amazon.com/codesuite/codedeploy/applications/lmbda-deploy-${ENV_NAME}/deployment-groups/lambda-deploy-group-${ENV_NAME}"
-        URL="https://api.bitbucket.org/2.0/repositories/tolunaengineering/${APP_NAME}/commit/$COMMIT_ID/statuses/build/"
+        URL="https://api.bitbucket.org/2.0/repositories/${SOURCE_REPOSITORY}/commit/$COMMIT_ID/statuses/build/"
         curl --request POST --url $URL -u "$BB_USER:$BB_PASS" --header "Accept:application/json" --header "Content-Type:application/json" --data "{\"key\":\"${APP_NAME} Deploy\",\"state\":\"SUCCESSFUL\",\"description\":\"Deployment to ${ENV_NAME} succeeded\",\"url\":\"$REPORT_URL\"}"    
       - |
         if [ "${ENV_NAME}" == "prod" ] && [ "${ENABLE_JIRA_AUTOMATION}" == "true" ] ; then 


### PR DESCRIPTION
I've changed APP_NAME to SOURCE_REPOSITORY in requests to tolunaengineering because not always app_name == repository in bitbucket.
(we did such change 2 month ago for build step)